### PR TITLE
Fix broadcast and restrict promo codes to single use

### DIFF
--- a/bot/database/methods/update.py
+++ b/bot/database/methods/update.py
@@ -54,13 +54,20 @@ def update_category(category_name: str, new_name: str) -> None:
     Database().session.commit()
 
 
-def update_promocode(code: str, discount: int | None = None, expires_at: str | None = None) -> None:
-    """Update promo code discount or expiry date."""
+def update_promocode(
+    code: str,
+    discount: int | None = None,
+    expires_at: str | None = None,
+    active: bool | None = None,
+) -> None:
+    """Update promo code discount, expiry date or activity."""
     values = {}
     if discount is not None:
         values[PromoCode.discount] = discount
     if expires_at is not None or expires_at is None:
         values[PromoCode.expires_at] = expires_at
+    if active is not None:
+        values[PromoCode.active] = active
     if not values:
         return
     Database().session.query(PromoCode).filter(PromoCode.code == code).update(values=values)

--- a/bot/handlers/admin/broadcast.py
+++ b/bot/handlers/admin/broadcast.py
@@ -17,45 +17,58 @@ async def send_message_callback_handler(call: CallbackQuery):
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
     role = check_role(user_id)
     if role & Permission.BROADCAST:
-        await bot.edit_message_text(chat_id=call.message.chat.id,
-                                    message_id=call.message.message_id,
-                                    text='Send the message for broadcast:',
-                                    reply_markup=back("console"))
+        await bot.edit_message_text(
+            chat_id=call.message.chat.id,
+            message_id=call.message.message_id,
+            text='Send the message for broadcast:',
+            reply_markup=back("console"),
+        )
         return
     await call.answer('Insufficient rights')
 
 
 async def broadcast_messages(message: Message):
-    bot, user_id = await get_bot_user_ids(message)
-    user_info = await bot.get_chat(user_id)
-    msg = message.text
-    message_id = TgConfig.STATE.get(f'{user_id}_message_id')
-    TgConfig.STATE[user_id] = None
-    await bot.delete_message(chat_id=message.chat.id,
-                             message_id=message.message_id)
+    bot, sender_id = await get_bot_user_ids(message)
+    user_info = await bot.get_chat(sender_id)
+    original_message = message
+    message_id = TgConfig.STATE.get(f'{sender_id}_message_id')
+    TgConfig.STATE[sender_id] = None
+    await bot.delete_message(
+        chat_id=message.chat.id,
+        message_id=message.message_id,
+    )
     users = get_all_users()
     max_users = 0
     for user_row in users:
         max_users += 1
-        user_id = user_row[0]
+        target_id = user_row[0]
         await asyncio.sleep(0.1)
         try:
-            await bot.send_message(chat_id=int(user_id),
-                                   text=msg,
-                                   reply_markup=close())
+            await original_message.send_copy(
+                chat_id=int(target_id),
+                reply_markup=close(),
+            )
         except BotBlocked:
             pass
-    await bot.edit_message_text(chat_id=message.chat.id,
-                                message_id=message_id,
-                                text='Broadcast finished',
-                                reply_markup=back("console"))
-    logger.info(f"User {user_info.id} ({user_info.first_name})"
-                f" performed a broadcast. Message was sent to {max_users} users.")
+    TgConfig.STATE.pop(f'{sender_id}_message_id', None)
+    await bot.edit_message_text(
+        chat_id=message.chat.id,
+        message_id=message_id,
+        text='Broadcast finished',
+        reply_markup=back("console"),
+    )
+    logger.info(
+        f"User {user_info.id} ({user_info.first_name}) performed a broadcast. "
+        f"Message was sent to {max_users} users."
+    )
 
 
 def register_mailing(dp: Dispatcher) -> None:
-    dp.register_callback_query_handler(send_message_callback_handler,
-                                       lambda c: c.data == 'send_message')
+    dp.register_callback_query_handler(
+        send_message_callback_handler, lambda c: c.data == 'send_message'
+    )
 
-    dp.register_message_handler(broadcast_messages,
-                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'waiting_for_message')
+    dp.register_message_handler(
+        broadcast_messages,
+        lambda c: TgConfig.STATE.get(c.from_user.id) == 'waiting_for_message',
+    )

--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -22,7 +22,7 @@ from bot.database.methods import (
     select_user_operations, select_user_items, start_operation,
     select_unfinished_operations, get_user_referral, finish_operation, update_balance, create_operation,
     bought_items_list, check_value, get_subcategories, get_category_parent, get_user_language, update_user_language,
-    get_unfinished_operation, get_promocode
+    get_unfinished_operation, get_promocode, update_promocode
 )
 from bot.handlers.other import get_bot_user_ids, get_bot_info
 from bot.keyboards import (
@@ -637,6 +637,7 @@ async def process_promo_code(message: Message):
         discount = promo['discount']
         new_price = round(price * (100 - discount) / 100, 2)
         TgConfig.STATE[f'{user_id}_price'] = new_price
+        update_promocode(code, active=False)
         text = t(lang, 'promo_applied', price=new_price)
     else:
         text = t(lang, 'promo_invalid')


### PR DESCRIPTION
## Summary
- Deactivate promo codes after first use to prevent reuse
- Improve broadcast handler to copy original message and avoid state clashes

## Testing
- `python -m py_compile bot/database/methods/update.py bot/handlers/user/main.py bot/handlers/admin/broadcast.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5ac31caa883328dc06d173e8df0d4